### PR TITLE
Fix nested plugin serialization

### DIFF
--- a/generator/generate_mitsuba_api.py
+++ b/generator/generate_mitsuba_api.py
@@ -29,6 +29,10 @@ class Plugin:
             v = getattr(self, f.name)
             if v is None:
                 continue
+            if isinstance(v, list) and v and hasattr(v[0], 'to_dict'):
+                for i, item in enumerate(v):
+                    out[f"{f.name}_{i}"] = serialize(item)
+                continue
             out[f.name] = serialize(v)
         return out
 
@@ -475,12 +479,22 @@ def render_class(spec: Dict[str, object], category_name: str) -> str:
         is_required = "required" in flags
 
         for raw_name in split_names(p.get("name", "param")):
-            nm = normalize(raw_name)
-            if nm in seen:
-                continue
-            base_ann = map_type(p.get("type", ""))
-            ann = base_ann if is_required else f"Optional[{base_ann}]"
-            nm = unique(nm)
+            # Nested plugin: use the type category as the field name
+            if raw_name.strip() == "(Nested plugin)":
+                ptype_raw = (p.get("type", "") or "").strip().lower()
+                nm = normalize(ptype_raw) if ptype_raw else "nested_plugin"
+                if nm in seen:
+                    continue
+                base_ann = "Union[Plugin, List[Plugin]]"
+                ann = base_ann if is_required else f"Optional[{base_ann}]"
+                nm = unique(nm)
+            else:
+                nm = normalize(raw_name)
+                if nm in seen:
+                    continue
+                base_ann = map_type(p.get("type", ""))
+                ann = base_ann if is_required else f"Optional[{base_ann}]"
+                nm = unique(nm)
 
             if is_required:
                 required_fields.append(f"    {nm}: {ann}")

--- a/mitsuba_scene_description/bsdfs.py
+++ b/mitsuba_scene_description/bsdfs.py
@@ -372,21 +372,24 @@ class BumpMapBsdfAdapter(Plugin):
     https://mitsuba.readthedocs.io/en/v3.7.1/src/generated/plugins_bsdfs.html#bumpmap
     Params:
         - (Nested plugin) (texture): [P | ∂ | D] Specifies the bump map texture.
+        - (Nested plugin) (bsdf): [P | ∂ | D] A BSDF model that should be affected by the bump map
         - scale (float): [P] Bump map gradient multiplier. (Default: 1.0)
         - flip_invalid_normals (boolean): [P] If enabled, the plugin will ensure that the perturbed normals are always
 consistent with the geometric normal. This prevents visual artifacts and is
 achieved by a simply flipping the shading normal, as described in [ SchusslerHHD17 ] . (Default: true)
         - use_shadowing_function (boolean): [P] If enabled, the plugin uses a Microfacet-based shadowing term [ ELS19 ] to smooth out transitions on shadow boundaries. (Default: true)
     """
-    nested_plugin: Optional[Plugin] = None
+    texture: Optional[Union[Plugin, List[Plugin]]] = None
+    bsdf: Optional[Union[Plugin, List[Plugin]]] = None
     scale: Optional[float] = None
     flip_invalid_normals: Optional[bool] = None
     use_shadowing_function: Optional[bool] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None, scale: Optional[float] = None, flip_invalid_normals: Optional[bool] = None, use_shadowing_function: Optional[bool] = None):
+    def __init__(self, id: Optional[str] = None, texture: Optional[Union[Plugin, List[Plugin]]] = None, bsdf: Optional[Union[Plugin, List[Plugin]]] = None, scale: Optional[float] = None, flip_invalid_normals: Optional[bool] = None, use_shadowing_function: Optional[bool] = None):
         super().__init__(type="bumpmap", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.texture = texture
+        self.bsdf = bsdf
         self.scale = scale
         self.flip_invalid_normals = flip_invalid_normals
         self.use_shadowing_function = use_shadowing_function
@@ -404,15 +407,15 @@ achieved by a simply flipping the shading normal, as described in [ SchusslerHHD
         - use_shadowing_function (boolean): [P] If enabled, the plugin uses a Microfacet-based shadowing term [ ELS19 ] to smooth out transitions on shadow boundaries. (Default: true)
     """
     normalmap: Optional[Plugin] = None
-    nested_plugin: Optional[Plugin] = None
+    bsdf: Optional[Union[Plugin, List[Plugin]]] = None
     flip_invalid_normals: Optional[bool] = None
     use_shadowing_function: Optional[bool] = None
 
-    def __init__(self, id: Optional[str] = None, normalmap: Optional[Plugin] = None, nested_plugin: Optional[Plugin] = None, flip_invalid_normals: Optional[bool] = None, use_shadowing_function: Optional[bool] = None):
+    def __init__(self, id: Optional[str] = None, normalmap: Optional[Plugin] = None, bsdf: Optional[Union[Plugin, List[Plugin]]] = None, flip_invalid_normals: Optional[bool] = None, use_shadowing_function: Optional[bool] = None):
         super().__init__(type="normalmap", id=id)
         self.id = id
         self.normalmap = normalmap
-        self.nested_plugin = nested_plugin
+        self.bsdf = bsdf
         self.flip_invalid_normals = flip_invalid_normals
         self.use_shadowing_function = use_shadowing_function
 
@@ -427,13 +430,13 @@ accordingly. (Default: 0.5)
         - (Nested plugin) (bsdf): [P | ∂] Two nested BSDF instances that should be mixed according to the specified blending weight
     """
     weight: Optional[float] = None
-    nested_plugin: Optional[Plugin] = None
+    bsdf: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, weight: Optional[float] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, weight: Optional[float] = None, bsdf: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="blendbsdf", id=id)
         self.id = id
         self.weight = weight
-        self.nested_plugin = nested_plugin
+        self.bsdf = bsdf
 
 @dataclass
 class OpacityMask(Plugin):
@@ -444,13 +447,13 @@ class OpacityMask(Plugin):
         - (Nested plugin) (bsdf): [P | ∂] A base BSDF model that represents the non-transparent portion of the scattering
     """
     opacity: Optional[Union[List[float], Plugin]] = None
-    nested_plugin: Optional[Plugin] = None
+    bsdf: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, opacity: Optional[Union[List[float], Plugin]] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, opacity: Optional[Union[List[float], Plugin]] = None, bsdf: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="mask", id=id)
         self.id = id
         self.opacity = opacity
-        self.nested_plugin = nested_plugin
+        self.bsdf = bsdf
 
 @dataclass
 class TwoSidedBrdfAdapter(Plugin):
@@ -459,12 +462,12 @@ class TwoSidedBrdfAdapter(Plugin):
     Params:
         - (Nested plugin) (bsdf): [P | ∂] A nested BRDF that should be turned into a two-sided scattering model. If two BRDFs are specified, they will be placed on the front and back side, respectively
     """
-    nested_plugin: Optional[Plugin] = None
+    bsdf: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, bsdf: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="twosided", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.bsdf = bsdf
 
 @dataclass
 class LinearPolarizerMaterial(Plugin):

--- a/mitsuba_scene_description/films.py
+++ b/mitsuba_scene_description/films.py
@@ -56,12 +56,12 @@ Gaussian filter)
     crop_height: Optional[int] = None
     sample_border: Optional[bool] = None
     compensate: Optional[bool] = None
-    nested_plugin: Optional[Plugin] = None
+    rfilter: Optional[Union[Plugin, List[Plugin]]] = None
     size: Optional[Plugin] = None
     crop_size: Optional[Plugin] = None
     crop_offset: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, width: Optional[int] = None, height: Optional[int] = None, file_format: Optional[str] = None, pixel_format: Optional[str] = None, component_format: Optional[str] = None, crop_offset_x: Optional[int] = None, crop_offset_y: Optional[int] = None, crop_width: Optional[int] = None, crop_height: Optional[int] = None, sample_border: Optional[bool] = None, compensate: Optional[bool] = None, nested_plugin: Optional[Plugin] = None, size: Optional[Plugin] = None, crop_size: Optional[Plugin] = None, crop_offset: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, width: Optional[int] = None, height: Optional[int] = None, file_format: Optional[str] = None, pixel_format: Optional[str] = None, component_format: Optional[str] = None, crop_offset_x: Optional[int] = None, crop_offset_y: Optional[int] = None, crop_width: Optional[int] = None, crop_height: Optional[int] = None, sample_border: Optional[bool] = None, compensate: Optional[bool] = None, rfilter: Optional[Union[Plugin, List[Plugin]]] = None, size: Optional[Plugin] = None, crop_size: Optional[Plugin] = None, crop_offset: Optional[Plugin] = None):
         super().__init__(type="hdrfilm", id=id)
         self.id = id
         self.width = width
@@ -75,7 +75,7 @@ Gaussian filter)
         self.crop_height = crop_height
         self.sample_border = sample_border
         self.compensate = compensate
-        self.nested_plugin = nested_plugin
+        self.rfilter = rfilter
         self.size = size
         self.crop_size = crop_size
         self.crop_offset = crop_offset
@@ -125,13 +125,13 @@ Gaussian filter)
     crop_height: Optional[int] = None
     sample_border: Optional[bool] = None
     compensate: Optional[bool] = None
-    nested_plugin: Optional[Plugin] = None
+    rfilter: Optional[Union[Plugin, List[Plugin]]] = None
     nested_plugins: Optional[Union[List[float], Plugin]] = None
     size: Optional[Plugin] = None
     crop_size: Optional[Plugin] = None
     crop_offset: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, width: Optional[int] = None, height: Optional[int] = None, component_format: Optional[str] = None, crop_offset_x: Optional[int] = None, crop_offset_y: Optional[int] = None, crop_width: Optional[int] = None, crop_height: Optional[int] = None, sample_border: Optional[bool] = None, compensate: Optional[bool] = None, nested_plugin: Optional[Plugin] = None, nested_plugins: Optional[Union[List[float], Plugin]] = None, size: Optional[Plugin] = None, crop_size: Optional[Plugin] = None, crop_offset: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, width: Optional[int] = None, height: Optional[int] = None, component_format: Optional[str] = None, crop_offset_x: Optional[int] = None, crop_offset_y: Optional[int] = None, crop_width: Optional[int] = None, crop_height: Optional[int] = None, sample_border: Optional[bool] = None, compensate: Optional[bool] = None, rfilter: Optional[Union[Plugin, List[Plugin]]] = None, nested_plugins: Optional[Union[List[float], Plugin]] = None, size: Optional[Plugin] = None, crop_size: Optional[Plugin] = None, crop_offset: Optional[Plugin] = None):
         super().__init__(type="specfilm", id=id)
         self.id = id
         self.width = width
@@ -143,7 +143,7 @@ Gaussian filter)
         self.crop_height = crop_height
         self.sample_border = sample_border
         self.compensate = compensate
-        self.nested_plugin = nested_plugin
+        self.rfilter = rfilter
         self.nested_plugins = nested_plugins
         self.size = size
         self.crop_size = crop_size

--- a/mitsuba_scene_description/integrators.py
+++ b/mitsuba_scene_description/integrators.py
@@ -69,13 +69,13 @@ class ArbitraryOutputVariablesIntegrator(Plugin):
 respective output will be put into distinct images.
     """
     aovs: Optional[str] = None
-    nested_plugin: Optional[Plugin] = None
+    integrator: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, aovs: Optional[str] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, aovs: Optional[str] = None, integrator: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="aov", id=id)
         self.id = id
         self.aovs = aovs
-        self.nested_plugin = nested_plugin
+        self.integrator = integrator
 
 @dataclass
 class VolumetricPathTracer(Plugin):
@@ -299,12 +299,12 @@ class MomentIntegrator(Plugin):
         - (Nested plugin) (integrator):  Sub-integrators (can have more than one) which will be sampled along the AOV integrator. Their
 respective XYZ output will be put into distinct images.
     """
-    nested_plugin: Optional[Plugin] = None
+    integrator: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, integrator: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="moment", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.integrator = integrator
 
 @dataclass
 class StokesVectorIntegrator(Plugin):
@@ -315,12 +315,12 @@ class StokesVectorIntegrator(Plugin):
 integrator. In polarized rendering modes, its output Stokes vector is written
 into distinct images.
     """
-    nested_plugin: Optional[Plugin] = None
+    integrator: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, integrator: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="stokes", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.integrator = integrator
 
 @dataclass
 class ParticleTracer(Plugin):

--- a/mitsuba_scene_description/media.py
+++ b/mitsuba_scene_description/media.py
@@ -28,16 +28,16 @@ isotropic.
     sigma_t: Optional[float] = None
     scale: Optional[float] = None
     sample_emitters: Optional[bool] = None
-    nested_plugin: Optional[Plugin] = None
+    phase: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, albedo: Optional[float] = None, sigma_t: Optional[float] = None, scale: Optional[float] = None, sample_emitters: Optional[bool] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, albedo: Optional[float] = None, sigma_t: Optional[float] = None, scale: Optional[float] = None, sample_emitters: Optional[bool] = None, phase: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="homogeneous", id=id)
         self.id = id
         self.albedo = albedo
         self.sigma_t = sigma_t
         self.scale = scale
         self.sample_emitters = sample_emitters
-        self.nested_plugin = nested_plugin
+        self.phase = phase
 
 @dataclass
 class HeterogeneousMedium(Plugin):
@@ -62,13 +62,13 @@ isotropic.
     sigma_t: Optional[float] = None
     scale: Optional[float] = None
     sample_emitters: Optional[bool] = None
-    nested_plugin: Optional[Plugin] = None
+    phase: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, albedo: Optional[float] = None, sigma_t: Optional[float] = None, scale: Optional[float] = None, sample_emitters: Optional[bool] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, albedo: Optional[float] = None, sigma_t: Optional[float] = None, scale: Optional[float] = None, sample_emitters: Optional[bool] = None, phase: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="heterogeneous", id=id)
         self.id = id
         self.albedo = albedo
         self.sigma_t = sigma_t
         self.scale = scale
         self.sample_emitters = sample_emitters
-        self.nested_plugin = nested_plugin
+        self.phase = phase

--- a/mitsuba_scene_description/phase.py
+++ b/mitsuba_scene_description/phase.py
@@ -71,13 +71,13 @@ function respectively, and in-between values interpolate accordingly.
 specified blending weight
     """
     weight: Optional[float] = None
-    nested_plugin: Optional[Plugin] = None
+    phase: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, weight: Optional[float] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, weight: Optional[float] = None, phase: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="blendphase", id=id)
         self.id = id
         self.weight = weight
-        self.nested_plugin = nested_plugin
+        self.phase = phase
 
 @dataclass
 class LookupTablePhaseFunction(Plugin):

--- a/mitsuba_scene_description/shapes.py
+++ b/mitsuba_scene_description/shapes.py
@@ -428,13 +428,13 @@ class ShapeGroup(Plugin):
         - (Nested plugin) (shape):  One or more shapes that should be made available for geometry instancing
         - bsdf (bsdf): [P] Surface scattering model
     """
-    nested_plugin: Optional[Plugin] = None
+    shape: Optional[Union[Plugin, List[Plugin]]] = None
     bsdf: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None, bsdf: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, shape: Optional[Union[Plugin, List[Plugin]]] = None, bsdf: Optional[Plugin] = None):
         super().__init__(type="shapegroup", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.shape = shape
         self.bsdf = bsdf
 
 @dataclass
@@ -446,14 +446,14 @@ class Instance(Plugin):
         - to_world (transform): [P | ∂ | D] Specifies a linear object-to-world transformation. (Default: none (i.e. object space = world space))
         - bsdf (bsdf): [P] Surface scattering model
     """
-    nested_plugin: Optional[Plugin] = None
+    shapegroup: Optional[Union[Plugin, List[Plugin]]] = None
     to_world: Optional[Transform] = None
     bsdf: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, nested_plugin: Optional[Plugin] = None, to_world: Optional[Transform] = None, bsdf: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, shapegroup: Optional[Union[Plugin, List[Plugin]]] = None, to_world: Optional[Transform] = None, bsdf: Optional[Plugin] = None):
         super().__init__(type="instance", id=id)
         self.id = id
-        self.nested_plugin = nested_plugin
+        self.shapegroup = shapegroup
         self.to_world = to_world
         self.bsdf = bsdf
 
@@ -495,10 +495,10 @@ as used in the volprim_rf_basic integrator.
     extent: Optional[float] = None
     extent_adaptive_clamping: Optional[float] = None
     to_world: Optional[Transform] = None
-    nested_plugin: Optional[Plugin] = None
+    tensor: Optional[Union[Plugin, List[Plugin]]] = None
     bsdf: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, filename: Optional[str] = None, data: Optional[Plugin] = None, centers: Optional[Plugin] = None, scales: Optional[Plugin] = None, quaternions: Optional[Plugin] = None, scale_factor: Optional[float] = None, extent: Optional[float] = None, extent_adaptive_clamping: Optional[float] = None, to_world: Optional[Transform] = None, nested_plugin: Optional[Plugin] = None, bsdf: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, filename: Optional[str] = None, data: Optional[Plugin] = None, centers: Optional[Plugin] = None, scales: Optional[Plugin] = None, quaternions: Optional[Plugin] = None, scale_factor: Optional[float] = None, extent: Optional[float] = None, extent_adaptive_clamping: Optional[float] = None, to_world: Optional[Transform] = None, tensor: Optional[Union[Plugin, List[Plugin]]] = None, bsdf: Optional[Plugin] = None):
         super().__init__(type="ellipsoids", id=id)
         self.id = id
         self.filename = filename
@@ -510,7 +510,7 @@ as used in the volprim_rf_basic integrator.
         self.extent = extent
         self.extent_adaptive_clamping = extent_adaptive_clamping
         self.to_world = to_world
-        self.nested_plugin = nested_plugin
+        self.tensor = tensor
         self.bsdf = bsdf
 
 @dataclass
@@ -552,10 +552,10 @@ as used in the volprim_rf_basic integrator.
     extent_adaptive_clamping: Optional[float] = None
     shell: Optional[str] = None
     to_world: Optional[Transform] = None
-    nested_plugin: Optional[Plugin] = None
+    tensor: Optional[Union[Plugin, List[Plugin]]] = None
     bsdf: Optional[Plugin] = None
 
-    def __init__(self, id: Optional[str] = None, filename: Optional[str] = None, data: Optional[Plugin] = None, centers: Optional[Plugin] = None, scales: Optional[Plugin] = None, quaternions: Optional[Plugin] = None, scale_factor: Optional[float] = None, extent: Optional[float] = None, extent_adaptive_clamping: Optional[float] = None, shell: Optional[str] = None, to_world: Optional[Transform] = None, nested_plugin: Optional[Plugin] = None, bsdf: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, filename: Optional[str] = None, data: Optional[Plugin] = None, centers: Optional[Plugin] = None, scales: Optional[Plugin] = None, quaternions: Optional[Plugin] = None, scale_factor: Optional[float] = None, extent: Optional[float] = None, extent_adaptive_clamping: Optional[float] = None, shell: Optional[str] = None, to_world: Optional[Transform] = None, tensor: Optional[Union[Plugin, List[Plugin]]] = None, bsdf: Optional[Plugin] = None):
         super().__init__(type="ellipsoidsmesh", id=id)
         self.id = id
         self.filename = filename
@@ -568,5 +568,5 @@ as used in the volprim_rf_basic integrator.
         self.extent_adaptive_clamping = extent_adaptive_clamping
         self.shell = shell
         self.to_world = to_world
-        self.nested_plugin = nested_plugin
+        self.tensor = tensor
         self.bsdf = bsdf

--- a/mitsuba_scene_description/spectra.py
+++ b/mitsuba_scene_description/spectra.py
@@ -93,14 +93,14 @@ class D65Spectrum(Plugin):
     """
     color: Optional[List[float]] = None
     scale: Optional[float] = None
-    nested_plugin: Optional[Plugin] = None
+    texture: Optional[Union[Plugin, List[Plugin]]] = None
 
-    def __init__(self, id: Optional[str] = None, color: Optional[List[float]] = None, scale: Optional[float] = None, nested_plugin: Optional[Plugin] = None):
+    def __init__(self, id: Optional[str] = None, color: Optional[List[float]] = None, scale: Optional[float] = None, texture: Optional[Union[Plugin, List[Plugin]]] = None):
         super().__init__(type="d65", id=id)
         self.id = id
         self.color = color
         self.scale = scale
-        self.nested_plugin = nested_plugin
+        self.texture = texture
 
 @dataclass
 class RawConstantValuedTexture(Plugin):

--- a/mitsuba_scene_description/utils.py
+++ b/mitsuba_scene_description/utils.py
@@ -16,6 +16,10 @@ class Plugin:
             v = getattr(self, f.name)
             if v is None:
                 continue
+            if isinstance(v, list) and v and hasattr(v[0], 'to_dict'):
+                for i, item in enumerate(v):
+                    out[f"{f.name}_{i}"] = serialize(item)
+                continue
             out[f.name] = serialize(v)
         return out
 


### PR DESCRIPTION
## Summary
- Use nested plugin's type category (`bsdf`, `texture`, `integrator`, etc.) as the field name instead of generic `nested_plugin`
- Support both single plugins and lists with `Optional[Union[Plugin, List[Plugin]]]` typing
- Serialize plugin lists with numbered keys (`bsdf_0`, `bsdf_1`) as Mitsuba expects

## Test plan
- [x] Verify `BlendedMaterial(weight=0.5, bsdf=[d, c]).to_dict()` produces `{"type": "blendbsdf", "weight": 0.5, "bsdf_0": {...}, "bsdf_1": {...}}`
- [x] Verify `TwoSidedBrdfAdapter(bsdf=d).to_dict()` produces `{"type": "twosided", "bsdf": {...}}`
- [x] Verify `BumpMapBsdfAdapter(texture=t, bsdf=b).to_dict()` produces separate `texture` and `bsdf` keys
- [x] Verify regenerated API has no remaining `nested_plugin` fields

Closes #2